### PR TITLE
feat: Add initial frontend unit tests and coverage plan

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13719,7 +13719,6 @@
             "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.5.5.tgz",
             "integrity": "sha512-PUykbixXEYSltKQE4450YuBiO8SMo2SwdGRHAdArRuV06Igq8gaLRVt9j8suj/4qtm2xRqoKnh5j52R0PfQxFw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "esbuild-wasm": ">=0.15.13",

--- a/frontend/src/app/core/guards/auth.guard.spec.ts
+++ b/frontend/src/app/core/guards/auth.guard.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router, UrlTree, CanActivateFn, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+import { authGuard } from './auth.guard';
+import { IAuthService } from '../services/auth.service.interface';
+import { AUTH_SERVICE_TOKEN } from '../services/injection-tokens';
+import { User, UserRole } from '../models/user.model';
+
+describe('authGuard', () => {
+  let authServiceMock: { currentUser$: BehaviorSubject<User | null | undefined> };
+  let routerMock: { navigate: jest.Mock, parseUrl: jest.Mock };
+  let guard: CanActivateFn;
+
+  // Mock ActivatedRouteSnapshot and RouterStateSnapshot
+  const mockActivatedRouteSnapshot = {} as ActivatedRouteSnapshot;
+  const mockRouterStateSnapshot = { url: '/test-url' } as RouterStateSnapshot;
+
+  beforeEach(() => {
+    authServiceMock = {
+      currentUser$: new BehaviorSubject<User | null | undefined>(null)
+    };
+
+    routerMock = {
+      navigate: jest.fn(),
+      parseUrl: jest.fn((url: string) => {
+        // A simple mock for UrlTree, real UrlTree is more complex
+        return {
+          toString: () => url,
+          queryParams: {},
+          fragment: null,
+          root: {
+            children: [],
+            segments: [],
+            parent: null,
+            pathFromRoot: []
+          },
+          hasChildren: () => false,
+          numberOfChildren: 0
+        } as unknown as UrlTree;
+      })
+    };
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule], // Useful for router-related testing utilities
+      providers: [
+        // authGuard is a function, not a class, so we don't provide it directly here.
+        // We will call it directly in tests, but its dependencies need to be mocked via TestBed's DI.
+        { provide: AUTH_SERVICE_TOKEN, useValue: authServiceMock },
+        { provide: Router, useValue: routerMock }
+      ]
+    });
+    
+    // The guard is a function, so we get its instance by using TestBed.runInInjectionContext
+    // to resolve its dependencies (authService and router) from the TestBed injector.
+    guard = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => 
+      TestBed.runInInjectionContext(() => authGuard(route, state));
+  });
+
+  it('should be created (conceptually, as it is a function)', () => {
+    // We don't instantiate functional guards directly, but we test their behavior.
+    // This test mainly ensures the setup is correct.
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    it('should return true and not navigate if the user is authenticated', (done) => {
+      const dummyUser: User = { uid: '123', email: 'test@example.com', role: UserRole.PLAYER };
+      authServiceMock.currentUser$.next(dummyUser);
+
+      const result = guard(mockActivatedRouteSnapshot, mockRouterStateSnapshot);
+
+      if (result instanceof Observable) {
+        result.subscribe(canActivate => {
+          expect(canActivate).toBe(true);
+          expect(routerMock.navigate).not.toHaveBeenCalled();
+          done();
+        });
+      } else {
+        // Should be an Observable based on guard implementation
+        fail('Expected an Observable from authGuard');
+      }
+    });
+
+    it('should return false and navigate to login if the user is not authenticated', (done) => {
+      authServiceMock.currentUser$.next(null); // No user
+
+      const result = guard(mockActivatedRouteSnapshot, mockRouterStateSnapshot);
+      
+      if (result instanceof Observable) {
+        result.subscribe(canActivate => {
+          expect(canActivate).toBe(false); // The tap operator doesn't change emission, map does.
+          expect(routerMock.navigate).toHaveBeenCalledWith(['/frontpage/login'], { queryParams: { returnUrl: '/test-url' } });
+          done();
+        });
+      } else {
+         // Should be an Observable based on guard implementation
+        fail('Expected an Observable from authGuard');
+      }
+    });
+    
+    it('should return false and navigate to login if the user is undefined', (done) => {
+      authServiceMock.currentUser$.next(undefined); // Undefined user
+
+      const result = guard(mockActivatedRouteSnapshot, mockRouterStateSnapshot);
+      
+      if (result instanceof Observable) {
+        result.subscribe(canActivate => {
+          expect(canActivate).toBe(false);
+          expect(routerMock.navigate).toHaveBeenCalledWith(['/frontpage/login'], { queryParams: { returnUrl: '/test-url' } });
+          done();
+        });
+      } else {
+        fail('Expected an Observable from authGuard');
+      }
+    });
+  });
+});

--- a/frontend/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,265 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse, HttpRequest, HttpEvent } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { throwError, of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { PLATFORM_ID } from '@angular/core';
+
+import { errorInterceptor } from './error.interceptor';
+import { NotificationService } from '../services/notification.service';
+import { IAuthService } from '../services/auth.service.interface';
+import { AUTH_SERVICE_TOKEN } from '../services/injection-tokens';
+import { User } from '../models/user.model'; // For User type if needed in mock
+
+describe('ErrorInterceptor', () => {
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  let notificationServiceMock: jest.Mocked<NotificationService>;
+  let authServiceMock: jest.Mocked<IAuthService>;
+  let routerMock: jest.Mocked<Router>;
+
+  const testUrl = '/api/test';
+
+  function performRequest(expectError: boolean = true) {
+    const request = httpClient.get(testUrl);
+    return expectError 
+      ? request.pipe(catchError(err => of(err))) 
+      : request;
+  }
+
+  function setupTestBed(platform: 'browser' | 'server') {
+    notificationServiceMock = {
+      showError: jest.fn(),
+      showInfo: jest.fn(), // Added to satisfy jest.Mocked if NotificationService has these
+      showSuccess: jest.fn(), // Added
+      showWarning: jest.fn(), // Added
+    } as unknown as jest.Mocked<NotificationService>; // Using unknown for brevity
+
+    // Comprehensive IAuthService Mock
+    authServiceMock = {
+      currentUser$: of(null),
+      firebaseUser$: of(null),
+      backendToken$: of(null),
+      isAuthenticated$: of(false),
+      isDoneLoading$: of(true),
+      
+      currentUser: jest.fn().mockReturnValue(null),
+      firebaseUser: jest.fn().mockReturnValue(null),
+      backendToken: jest.fn().mockReturnValue(null),
+      isAuthenticated: jest.fn().mockReturnValue(false),
+      isUserPlayer: jest.fn().mockReturnValue(false),
+      isUserAdmin: jest.fn().mockReturnValue(false),
+      isUserSuperAdmin: jest.fn().mockReturnValue(false),
+      isAdmin: jest.fn().mockReturnValue(false),
+      isPlayer: jest.fn().mockReturnValue(false),
+      canImpersonate: jest.fn().mockReturnValue(false),
+      isImpersonating: jest.fn().mockReturnValue(false),
+      isProduction: jest.fn().mockReturnValue(false),
+      isEmulator: jest.fn().mockReturnValue(false),
+      isLoggedIn: jest.fn().mockReturnValue(false),
+
+      logout: jest.fn().mockReturnValue(Promise.resolve()),
+      login: jest.fn().mockResolvedValue(undefined),
+      registerPlayer: jest.fn().mockResolvedValue(undefined),
+      adminRegister: jest.fn().mockResolvedValue(undefined),
+      handleSignInWithPopup: jest.fn().mockResolvedValue({} as any), // userCredential mock
+      sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+      impersonateUser: jest.fn().mockResolvedValue(undefined),
+      stopImpersonation: jest.fn().mockResolvedValue(undefined),
+      getRedirectResult: jest.fn().mockResolvedValue(null),
+      loginWithGoogle: jest.fn().mockResolvedValue({} as any), // userCredential mock
+      registerAdmin: jest.fn().mockResolvedValue(undefined), 
+      updateUserRole: jest.fn().mockResolvedValue(undefined),
+      updateUserProfile: jest.fn().mockResolvedValue(undefined),
+      deleteTestUser: jest.fn().mockResolvedValue(undefined),
+      getCurrentFirebaseIdToken: jest.fn().mockResolvedValue(null),
+      adminLogin: jest.fn().mockResolvedValue(undefined),
+      validateAdminRegistrationCode: jest.fn().mockResolvedValue(false),
+      refreshBackendToken: jest.fn().mockResolvedValue(false),
+      triggerPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+      playerLoginWithCredentials: jest.fn().mockResolvedValue(undefined),
+      requestPasswordReset: jest.fn().mockResolvedValue(undefined),
+      getStoredBackendTokenSnapshot: jest.fn().mockReturnValue(null),
+      impersonatePlayer: jest.fn().mockResolvedValue(undefined)
+    } as jest.Mocked<IAuthService>;
+    
+    routerMock = {
+      navigate: jest.fn()
+    } as unknown as jest.Mocked<Router>;
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { 
+          provide: HTTP_INTERCEPTORS, 
+          useValue: (req: HttpRequest<unknown>, next: (req: HttpRequest<unknown>) => Observable<HttpEvent<unknown>>) => 
+            TestBed.runInInjectionContext(() => errorInterceptor(req, next)), 
+          multi: true 
+        },
+        { provide: NotificationService, useValue: notificationServiceMock },
+        { provide: AUTH_SERVICE_TOKEN, useValue: authServiceMock },
+        { provide: Router, useValue: routerMock },
+        { provide: PLATFORM_ID, useValue: platform },
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  }
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+  
+  describe('Error handling in browser environment', () => {
+    beforeEach(() => {
+      setupTestBed('browser');
+    });
+
+    it('should show "Client-side error" and re-throw for ErrorEvent', (done) => {
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toMatch(/Client-side error: Test client error/);
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith('Client-side error: Test client error');
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.error(new ErrorEvent('Network error', { message: 'Test client error' }));
+    });
+
+    it('should handle 401 Unauthorized, call logout, and show notification', (done) => {
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe('Your session has expired or you are not authorized. Please log in again.');
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith('Your session has expired or you are not authorized. Please log in again.');
+        expect(authServiceMock.logout).toHaveBeenCalled();
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+    });
+    
+    it('should handle 403 Forbidden and show notification', (done) => {
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe('You do not have permission to access this resource or perform this action.');
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith('You do not have permission to access this resource or perform this action.');
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+    });
+
+    it('should handle 400 Bad Request with detail message and show notification', (done) => {
+      const detailMessage = 'Invalid input provided.';
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe(detailMessage);
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith(`Request error: ${detailMessage}`);
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: { detail: detailMessage } }, { status: 400, statusText: 'Bad Request' });
+    });
+    
+    it('should handle 400 Bad Request with string error and show notification', (done) => {
+        const stringErrorMsg = 'A specific bad request error string.';
+        performRequest().subscribe(response => {
+          expect(response).toBeInstanceOf(Error);
+          expect(response.message).toBe(stringErrorMsg);
+          expect(notificationServiceMock.showError).toHaveBeenCalledWith(`Request error: ${stringErrorMsg}`);
+          done();
+        });
+        const req = httpMock.expectOne(testUrl);
+        req.flush({ error: stringErrorMsg }, { status: 400, statusText: 'Bad Request' });
+      });
+
+    it('should handle 404 Not Found and show notification with error message', (done) => {
+      const errDetail = 'The requested item does not exist.';
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe(errDetail);
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith(`Resource not found: ${errDetail}`);
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: { detail: errDetail } }, { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle 500 Internal Server Error and show generic server error notification', (done) => {
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe('A server error occurred. Please try again later.');
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith('A server error occurred. Please try again later.');
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: 'Server broke' }, { status: 500, statusText: 'Internal Server Error' });
+    });
+    
+    it('should handle status 0 (network error) and show network error notification', (done) => {
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe('Could not connect to the server. Please check your network connection.');
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith('Could not connect to the server. Please check your network connection.');
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+    });
+
+    it('should handle default error and show notification with status and message', (done) => {
+      const detailMessage = 'Some other error';
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe(detailMessage);
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith(`Error 418: ${detailMessage}`);
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: { detail: detailMessage } }, { status: 418, statusText: 'I\'m a teapot' });
+    });
+    
+    it('should pass through successful responses without interference', (done) => {
+        const testData = { data: 'success' };
+        performRequest(false).subscribe(response => {
+          expect(response).toEqual(testData);
+          expect(notificationServiceMock.showError).not.toHaveBeenCalled();
+          expect(authServiceMock.logout).not.toHaveBeenCalled();
+          done();
+        });
+        const req = httpMock.expectOne(testUrl);
+        req.flush(testData); 
+      });
+  });
+  
+  describe('Error handling in server (SSR) environment', () => {
+    beforeEach(() => {
+      setupTestBed('server');
+    });
+
+    it('should NOT show "Client-side error" for ErrorEvent, but use server-side path', (done) => {
+      const serverErrorMessage = 'Simulated server error during SSR';
+      performRequest().subscribe(response => {
+        expect(response).toBeInstanceOf(Error);
+        expect(response.message).toBe(serverErrorMessage);
+        expect(notificationServiceMock.showError).toHaveBeenCalledWith(`Error 503: ${serverErrorMessage}`);
+        done();
+      });
+      const req = httpMock.expectOne(testUrl);
+      req.flush({ error: { detail: serverErrorMessage } }, { status: 503, statusText: 'Service Unavailable' });
+    });
+    
+    it('should NOT show network error for status 0, as it is not a browser network issue', (done) => {
+        performRequest().subscribe(response => {
+          expect(response).toBeInstanceOf(Error);
+          expect(response.message).toMatch(/Server error: 0 -/);
+          expect(notificationServiceMock.showError).not.toHaveBeenCalled(); 
+          done();
+        });
+        const req = httpMock.expectOne(testUrl);
+        req.error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' }); 
+      });
+  });
+});

--- a/frontend/src/app/features/game/components/plantation-dialog/plantation-dialog.component.spec.ts
+++ b/frontend/src/app/features/game/components/plantation-dialog/plantation-dialog.component.spec.ts
@@ -1,0 +1,113 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CommonModule } from '@angular/common';
+
+// Import Angular Material modules used by the component
+import { MatButtonModule } from '@angular/material/button';
+import { MatGridListModule } from '@angular/material/grid-list';
+
+import { PlantationDialogComponent } from './plantation-dialog.component';
+import { PlantationType } from '../../../../core/models/parcel.model';
+import { DisplayPlantationNamePipe } from '../../../../shared/pipes/display-plantation-name.pipe'; // Import the pipe
+
+// Mock MAT_DIALOG_DATA - even if not used by current component logic, it's good practice if dialogs often expect it.
+// For this component, it seems it doesn't use injected data to populate its list of plantations.
+const mockDialogData = { 
+  // parcelNumber: 1, // Example data, though not used by this specific component's logic
+  // currentPlantation: PlantationType.CORN // Also not directly used to filter or select
+};
+
+describe('PlantationDialogComponent', () => {
+  let component: PlantationDialogComponent;
+  let fixture: ComponentFixture<PlantationDialogComponent>;
+  let dialogRefMock: { close: jest.Mock };
+  let nativeElement: HTMLElement;
+
+  beforeEach(async () => {
+    dialogRefMock = {
+      close: jest.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CommonModule, // For *ngFor etc.
+        NoopAnimationsModule,
+        MatDialogModule, // Provides MatDialogRef, MAT_DIALOG_DATA implicitly
+        MatButtonModule,
+        MatGridListModule,
+        PlantationDialogComponent, // The standalone component itself
+        DisplayPlantationNamePipe  // The pipe used by the component
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefMock },
+        { provide: MAT_DIALOG_DATA, useValue: mockDialogData }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlantationDialogComponent);
+    component = fixture.componentInstance;
+    nativeElement = fixture.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display a button for each plantation type', () => {
+    const expectedPlantations = Object.values(PlantationType);
+    const plantationButtons = nativeElement.querySelectorAll<HTMLButtonElement>('.plantation-button');
+    expect(plantationButtons.length).toBe(expectedPlantations.length);
+
+    // Check if button text is correctly transformed by DisplayPlantationNamePipe
+    // This requires DisplayPlantationNamePipe to be correctly mocked or included if it's simple
+    // For now, we check if buttons are present. Content check can be more involved.
+    plantationButtons.forEach((button, index) => {
+      // To properly test the text, we'd need an instance of the pipe or a more complex setup.
+      // For now, let's assume the pipe works and buttons are rendered.
+      expect(button).toBeTruthy();
+    });
+  });
+  
+  it('should call dialogRef.close with the selected plantation when a plantation button is clicked', () => {
+    const cornButton = nativeElement.querySelector<HTMLButtonElement>('button[mat-button].plantation-button'); // Get the first button
+    
+    // Find a specific plantation to test, e.g., CORN
+    // This depends on the order, which is not ideal. A better way would be to add data-testid attributes.
+    // For now, let's assume CORN is one of the displayed buttons.
+    // We'll simulate a click on the button corresponding to PlantationType.CORN
+    // This requires knowing which button corresponds to CORN, or adding test IDs.
+
+    // Let's find the button for CORN more reliably if possible, or pick the first one.
+    // Assuming the buttons are rendered in the order of Object.values(PlantationType)
+    const cornIndex = Object.values(PlantationType).indexOf(PlantationType.CORN);
+    const plantationButtons = nativeElement.querySelectorAll<HTMLButtonElement>('.plantation-button');
+    
+    if (plantationButtons.length > cornIndex && cornIndex !== -1) {
+      plantationButtons[cornIndex].click();
+      expect(dialogRefMock.close).toHaveBeenCalledWith(PlantationType.CORN);
+    } else {
+      fail('Could not find a button for PlantationType.CORN to test click');
+    }
+  });
+
+  it('should generate correct CSS class for a plantation type', () => {
+    expect(component.getPlantationCssClass(PlantationType.FIELD_BEAN)).toBe('ackerbohne'); // Enum value is "Ackerbohne"
+    expect(component.getPlantationCssClass(PlantationType.SUGAR_BEET)).toBe('zuckerruebe'); // Enum value is "Zuckerruebe"
+  });
+  
+  // Test for a plantation type that might have underscore in its enum value if that was the case
+  // Example: if PlantationType had SOME_VALUE = "SOME_VALUE"
+  // it('should generate correct CSS class for plantation type with underscore', () => {
+  //   enum TestPlantationType { TEST_PLANT = "TEST_PLANT" }
+  //   expect(component.getPlantationCssClass(TestPlantationType.TEST_PLANT as any)).toBe('test-plant');
+  // });
+
+
+  it('should have a list of plantations available from PlantationType enum', () => {
+    expect(component.plantations.length).toEqual(Object.values(PlantationType).length);
+    expect(component.plantations).toEqual(expect.arrayContaining(Object.values(PlantationType)));
+  });
+
+});

--- a/frontend/src/app/shared/pipes/display-plantation-name.pipe.spec.ts
+++ b/frontend/src/app/shared/pipes/display-plantation-name.pipe.spec.ts
@@ -1,0 +1,83 @@
+import { DisplayPlantationNamePipe } from './display-plantation-name.pipe';
+import { PlantationType } from '../../core/models/parcel.model';
+
+describe('DisplayPlantationNamePipe', () => {
+  let pipe: DisplayPlantationNamePipe;
+
+  beforeEach(() => {
+    pipe = new DisplayPlantationNamePipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return "N/A" for null input', () => {
+    expect(pipe.transform(null)).toBe('N/A');
+  });
+
+  it('should return "N/A" for undefined input', () => {
+    expect(pipe.transform(undefined)).toBe('N/A');
+  });
+
+  it('should return the correct name for PlantationType.FALLOW', () => {
+    expect(pipe.transform(PlantationType.FALLOW)).toBe('Brachland');
+  });
+
+  it('should return the correct name for PlantationType.FIELD_BEAN', () => {
+    expect(pipe.transform(PlantationType.FIELD_BEAN)).toBe('Ackerbohne');
+  });
+
+  it('should return the correct name for PlantationType.BARLEY', () => {
+    expect(pipe.transform(PlantationType.BARLEY)).toBe('Gerste');
+  });
+  
+  it('should return the correct name for PlantationType.OAT', () => {
+    expect(pipe.transform(PlantationType.OAT)).toBe('Hafer');
+  });
+
+  it('should return the correct name for PlantationType.POTATO', () => {
+    expect(pipe.transform(PlantationType.POTATO)).toBe('Kartoffel');
+  });
+
+  it('should return the correct name for PlantationType.CORN', () => {
+    expect(pipe.transform(PlantationType.CORN)).toBe('Mais');
+  });
+
+  it('should return the correct name for PlantationType.RYE', () => {
+    expect(pipe.transform(PlantationType.RYE)).toBe('Roggen');
+  });
+
+  it('should return the correct name for PlantationType.ANIMAL_HUSBANDRY', () => {
+    expect(pipe.transform(PlantationType.ANIMAL_HUSBANDRY)).toBe('Tiere');
+  });
+
+  it('should return the correct name for PlantationType.WHEAT', () => {
+    expect(pipe.transform(PlantationType.WHEAT)).toBe('Weizen');
+  });
+
+  it('should return the correct name for PlantationType.SUGAR_BEET', () => {
+    // Note: The enum value is "Zuckerruebe", the map key is "Zuckerruebe", the map value is "Zuckerrübe"
+    expect(pipe.transform(PlantationType.SUGAR_BEET)).toBe('Zuckerrübe');
+  });
+
+  it('should return the input string if it is not a known PlantationType string value', () => {
+    expect(pipe.transform('UNKNOWN_PLANTATION_VALUE')).toBe('UNKNOWN_PLANTATION_VALUE');
+  });
+  
+  it('should return the input string if it is an enum member name like "BARLEY" but not its value', () => {
+    // This tests if providing the *name* of an enum member as a string (which is not its value)
+    // correctly falls back to returning the input string itself.
+    // PlantationType.BARLEY has the value "Gerste".
+    // The key in nameMap for Barley is "Gerste".
+    // So, inputting "BARLEY" (the enum member name) should not find a map entry.
+    expect(pipe.transform("BARLEY")).toBe("BARLEY");
+  });
+
+  // This test remains valid as PlantationType.CORN.valueOf() will give the actual enum string value
+  it('should handle string versions of enum values (from valueOf)', () => {
+    // PlantationType.CORN has the value "Mais". PlantationType.CORN.valueOf() is "Mais".
+    // The key in nameMap for Corn is "Mais".
+    expect(pipe.transform(PlantationType.CORN.valueOf())).toBe('Mais');
+  });
+});

--- a/frontend/src/app/shared/pipes/display-plantation-name.pipe.ts
+++ b/frontend/src/app/shared/pipes/display-plantation-name.pipe.ts
@@ -20,8 +20,8 @@ export class DisplayPlantationNamePipe implements PipeTransform {
   };
 
   transform(value: PlantationType | string | undefined | null): string {
-    if (!value) return 'N/A';
-    const key = typeof value === 'string' ? value : value.valueOf();
+    if (value === null || typeof value === 'undefined') return 'N/A';
+    const key = typeof value === 'string' ? value : String(value);
     return this.nameMap[key] || key;
   }
 }


### PR DESCRIPTION
Adds unit tests for:
- `DisplayPlantationNamePipe` (shared pipe)
- `authGuard` (core route guard)
- `PlantationDialogComponent` (features/game component)
- `errorInterceptor` (core HTTP interceptor)

This work establishes testing patterns for various types of Angular elements. During this process, a minor bug in `DisplayPlantationNamePipe` related to `valueOf()` was also corrected.

Includes a review of the current frontend test coverage and provides a set of recommendations for systematically increasing test coverage across components, other guards/interceptors, and for introducing integration and E2E tests, aligning with the project goal of "Full Test Coverage".